### PR TITLE
Add abandoned setting to composer.json pointing to cmdotcom/text-sdk-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "cmtelecom/messaging-php",
   "description": "PHP client for integration with the CM platform",
+  "abandoned": "cmdotcom/text-sdk-php",
   "keywords": [
     "cmtelecom",
     "cm",


### PR DESCRIPTION
This repository is not maintained anymore. Therefor this pull request adds the [abandoned](https://getcomposer.org/doc/04-schema.md#abandoned) setting pointing to the new maintained package https://packagist.org/packages/cmdotcom/text-sdk-php.